### PR TITLE
Fix SpriteComponent default constructor

### DIFF
--- a/Coconuts/include/coconuts/ecs/components/SpriteComponent.h
+++ b/Coconuts/include/coconuts/ecs/components/SpriteComponent.h
@@ -33,7 +33,12 @@ namespace Coconuts
         float                   tilingFactor;
         std::weak_ptr<Sprite>   sprite;
         
-        SpriteComponent() = default;        
+        SpriteComponent()
+        : spriteLogicalName("###unknown"), tintColor(glm::vec4(1.0f)), tilingFactor(1.0f)
+        {
+            // do nothing
+        }
+        
         SpriteComponent(const std::string& spriteName,
                         const glm::vec4& color = glm::vec4(1.0f),
                         float factor = 1.0f)


### PR DESCRIPTION
TileFactor can't be 0, otherwise sprite will not be rendered!